### PR TITLE
Resize dump before trying to skip by xing_offset

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,7 @@ pub fn from_read<T>(reader: &mut T) -> Result<Duration, Error>
 
             let xing_offset = get_side_information_size(version, mode)? as usize;
             let mut xing_buffer = [0; 12];
+            dump.resize(xing_offset, 0);
             match reader.read_exact(&mut dump[..xing_offset]) {
                 Ok(_) => (),
                 Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,


### PR DESCRIPTION
If a file has a zero-sized ID3 tag segment, the reader's dump buffer will have been resized to zero before reading the xing header.

No test file, unfortunately. The file I have isn't of appropriate license, and I haven't yet found a tool that can produce a empty un-padded ID3 header aside from trying to hex edit one up.