### PR TITLE
handle bad id3v2 padding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,6 +465,15 @@ fn id3v2_empty() {
 }
 
 #[test]
+fn id3v2_bad_padding() {
+    let path = Path::new("test/ID3v2WithBadPadding.mp3");
+    let duration = from_path(path).unwrap();
+    assert_eq!(398, duration.as_secs());
+    let nanos = duration.subsec_nanos();
+    assert!(2 < nanos && nanos < 3 * 100_000_000);
+}
+
+#[test]
 fn apev2() {
     let path = Path::new("test/APEv2.mp3");
     let duration = from_path(path).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,9 +176,9 @@ where
 
     let mut duration = Duration::from_secs(0);
     loop {
-        //skip over all 0x00 bytes (these are probably incorrectly added padding bytes for id3v2)
+        // Skip over all 0x00 bytes (these are probably incorrectly added padding bytes for id3v2)
         header_buffer[0] = 0;
-        while header_buffer[0] == 0{
+        while header_buffer[0] == 0 {
             match reader.read_exact(&mut header_buffer[0..1]) {
                 Ok(_) => (),
                 Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
@@ -329,8 +329,8 @@ where
             && header_buffer[1] == 'P' as u8
             && header_buffer[2] == 'E' as u8
             && header_buffer[3] == 'T' as u8;
-        if maybe_is_ape_v2{
-            let mut ape_header = [0;12];
+        if maybe_is_ape_v2 {
+            let mut ape_header = [0; 12];
             match reader.read_exact(&mut ape_header[..]) {
                 Ok(_) => (),
                 Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
@@ -340,7 +340,7 @@ where
                 && ape_header[1] == 'G' as u8
                 && ape_header[2] == 'E' as u8
                 && ape_header[3] == 'X' as u8;
-            if !is_really_ape_v2{
+            if !is_really_ape_v2 {
                 bail!(MP3DurationError::UnexpectedFrame { header: header });
             }
             let tag_size: usize = ((ape_header[8] as u32)
@@ -353,7 +353,6 @@ where
                 Err(e) => bail!(e),
             };
             continue;
-
         }
 
         bail!(MP3DurationError::UnexpectedFrame { header: header });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,17 @@ where
 
     let mut duration = Duration::from_secs(0);
     loop {
-        match reader.read_exact(&mut header_buffer[..]) {
+        //skip over all 0x00 bytes (these are probably incorrectly added padding bytes for id3v2)
+        header_buffer[0] = 0;
+        while header_buffer[0] == 0{
+            match reader.read_exact(&mut header_buffer[0..1]) {
+                Ok(_) => (),
+                Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(e) => bail!(e),
+            };
+        }
+
+        match reader.read_exact(&mut header_buffer[1..]) {
             Ok(_) => (),
             Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
             Err(e) => bail!(e),


### PR DESCRIPTION
I still have some more odd mp3-files in my collection ;)

This handles cases where there is padding after the id3v2 tag (0x00 bytes), but the padding is not added to the size field, resulting in the loop catching some 0x00 bytes and throwing a UnexpectedFrame Error with header:0. 

This way of padding is not id3v2-conform, but it appears anyway and players (e.g. VLC and others) can handle it quite well (Until now I never had any problems with playing the files)

This workaround "eats" all padding it finds, because it isn't quite as easy to only erase padding after id3 tags because the following byte must somehow appear in the next loop...

All other types of frames don't start with a 0x00-byte, so this shouldn't be a problem.

I took the id3v2 example and added a few zero-bytes after the id3 frame for the test. 