### PR TITLE
Add parsed duration and the file offset to the returned Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate failure;
 
 use core::fmt;


### PR DESCRIPTION
I had to change the original bail! macro because it changed all thrown errors into a ErrorMsg type with no way to extract the original Error.

This also changes the Error type from `failure::Error` to `MP3DurationError`.

I added the duration_at and offset fields, but only for the "Unknown Frame" error, should also I add this for the other types? I'd probably restructure MP3DurationError into a struct with a kind field containing the enum.
