### PR TITLE
Fix to regression when splitting into submodules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ use crate::constants::*;
 use crate::context::Context;
 use crate::error::*;
 
+pub use crate::error::MP3DurationError;
+
 fn get_bitrate<T: Read>(
     context: &Context<T>,
     version: Version,


### PR DESCRIPTION
Before splitting into submodules (commit de9692243131fdd88c9b954153aaa64c8af14160), the symbol MP3DurationError was exported as mp3_duration::MP3DurationError.  After the split, the symbol was still public, but inside a private module, which made it inaccessible.

This change restores the prior API by publicly re-exporting the symbol as mp3_duration::MP3DurationError.

Fixes https://github.com/agersant/mp3-duration/issues/11.