### PR TITLE
Export ErrorKind for matching against different Errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use crate::constants::*;
 use crate::context::Context;
 use crate::error::*;
 
-pub use crate::error::MP3DurationError;
+pub use crate::error::{MP3DurationError, ErrorKind};
 
 fn get_bitrate<T: Read>(
     context: &Context<T>,


### PR DESCRIPTION
An exported `ErrorKind` allows developers to decide if they want to keep a duration up to a specific error (like `UnexpectedEOF`) and abort on others (like `ForbiddenVersion`).

I've come to rely on this in my crooked library ;-)

This completes #12 (If I haven't missed something else).