### PR TITLE
failure → thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ exclude = [
 travis-ci = { repository = "agersant/mp3-duration", branch = "master" }
 
 [dependencies]
-failure = "0.1.5"
+thiserror = "1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,57 +1,42 @@
-use core::fmt;
-use failure::Fail;
 use std::io;
 use std::time::Duration;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[error("{} at offset {} (0x{1:X}); measured duration up to here: {:?}",
+        .kind, .offset, .at_duration)]
 pub struct MP3DurationError {
-	pub kind: ErrorKind,
-	pub offset: usize,
-	pub at_duration: Duration,
+    #[source]
+    pub kind: ErrorKind,
+    pub offset: usize,
+    pub at_duration: Duration,
 }
 
-impl fmt::Display for MP3DurationError {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(
-			f,
-			"{} at offset {} (0x{1:X}); measured duration up to here: {:?}",
-			self.kind, self.offset, self.at_duration
-		)
-	}
-}
-
-impl Fail for MP3DurationError {
-	// Delegate `cause` to ErrorKind
-	fn cause(&self) -> Option<&dyn Fail> {
-		self.kind.cause()
-	}
-}
-
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum ErrorKind {
-	#[fail(display = "Invalid MPEG version")]
-	ForbiddenVersion,
-	#[fail(display = "Invalid MPEG Layer (0)")]
-	ForbiddenLayer,
-	#[fail(display = "Invalid bitrate bits: {0} (0b{0:b})", bitrate)]
-	InvalidBitrate { bitrate: u8 },
-	#[fail(display = "Invalid sampling rate bits: {0} (0b{0:b})", sampling_rate)]
-	InvalidSamplingRate { sampling_rate: u8 },
-	#[fail(display = "Unexpected frame, header 0x{:X}", header)]
-	UnexpectedFrame { header: u32 },
-	#[fail(display = "Unexpected end of file")]
-	UnexpectedEOF,
-	#[fail(display = "MPEG frame too short")]
-	MPEGFrameTooShort,
-	#[fail(display = "Unexpected IO Error: {}", _0)]
-	IOError(#[fail(cause)] io::Error),
+    #[error("Invalid MPEG version")]
+    ForbiddenVersion,
+    #[error("Invalid MPEG Layer (0)")]
+    ForbiddenLayer,
+    #[error("Invalid bitrate bits: {0} (0b{0:b})", .bitrate)]
+    InvalidBitrate { bitrate: u8 },
+    #[error("Invalid sampling rate bits: {0} (0b{0:b})", .sampling_rate)]
+    InvalidSamplingRate { sampling_rate: u8 },
+    #[error("Unexpected frame, header 0x{:X}", .header)]
+    UnexpectedFrame { header: u32 },
+    #[error("Unexpected end of file")]
+    UnexpectedEOF,
+    #[error("MPEG frame too short")]
+    MPEGFrameTooShort,
+    #[error("Unexpected IO Error: {0}")]
+    IOError(#[source] io::Error),
 }
 
 impl From<io::Error> for ErrorKind {
-	fn from(e: io::Error) -> Self {
-		match e.kind() {
-			io::ErrorKind::UnexpectedEof => ErrorKind::UnexpectedEOF,
-			_ => ErrorKind::IOError(e),
-		}
-	}
+    fn from(e: io::Error) -> Self {
+        match e.kind() {
+            io::ErrorKind::UnexpectedEof => ErrorKind::UnexpectedEOF,
+            _ => ErrorKind::IOError(e),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate failure;
-
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
@@ -14,9 +12,8 @@ mod test;
 
 use crate::constants::*;
 use crate::context::Context;
-use crate::error::*;
 
-pub use crate::error::{MP3DurationError, ErrorKind};
+pub use crate::error::{ErrorKind, MP3DurationError};
 
 fn get_bitrate<T: Read>(
     context: &Context<T>,


### PR DESCRIPTION
`failure` is [deprecated](https://github.com/rust-lang-nursery/failure#failure---a-new-error-management-story). This is a breaking change, but I think it is worth to switch from a deprecated trait (`failure::Fail`) to `std::error::Error`.

Another option: Don't use `thiserror`, implement `Error + Display` manually (very tedious).